### PR TITLE
(patch): Issue with XRDP annoyance "Authentication Required to Create Managed Color Device"

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,10 +10,12 @@ xrdp:
   disable_screen_lock: true
   tls_enabled: true
   port: '3389'
+  colord_bypass: true
+  colord_group: xgui
 
 # Firewall configuration
 firewall:
-  enabled: true
+  enabled: false
   manager: ufw
   ssh: true
   ssh_port: 22

--- a/example.config.yml
+++ b/example.config.yml
@@ -10,10 +10,16 @@ xrdp:
   disable_screen_lock: true # disable automatic screen locking (works with gnome only)
   port: '3389'
   tls_enabled: true
+  # Colord sometimes prevents some applications from starting properly without authenticating first.
+  # Set colord_bypass to true and set an allowed group of users who can RDP to the system to bypass colord authentation
+  # This is a problem detailed here: https://askubuntu.com/questions/1245020/xrdp-on-ubuntu-20-04
+  # Note: this problem seems to be specific to the gnome desktop environment
+  colord_bypass: true
+  colord_group: xgui
 
 # Firewall configuration
 firewall:
-  enabled: true
+  enabled: false
   manager: ufw # Can be 'ufw' or 'iptables'
   ssh: true # Ensures that SSH connectivity remains even after XRDP is installed on the target
   ssh_port: 22 # SSH port to use (if other than 22)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,11 @@
 ---
 # handlers file for ansible-xrdp-ubuntu
 
+- name: Restart XRDP
+  ansible.builtin.systemd:
+    name: xrdp
+    state: restarted
+
 - name: Reload UFW
   community.general.ufw:
     state: enabled

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   namespace: sykesdev
   name: ansible-xrdp-ubuntu
-  version: '1.0.0'
+  version: '1.0.1'
   readme: "README.md"
   authors: 
     - "Benjamin Sykes<ben@sykesdev.ca>"

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -19,7 +19,8 @@
   when: xrdp.environment == "xfce"
 
 - name: UBUNTU | 4.0 | Initiate configuration of XRDP server
-  ansible.builtin.include_tasks: "xrdp.yml"
+  ansible.builtin.import_tasks: "xrdp.yml"
+  notify: Restart XRDP
 
 - name: UBUNTU | 4.0 | Include firewall config
   ansible.builtin.include_tasks: "firewall.yml"

--- a/tasks/xrdp.yml
+++ b/tasks/xrdp.yml
@@ -59,11 +59,11 @@
 - name: XRDP | 9.0 | Patch Polkit
   block:
     - name: XRDP | 9.1 | Gather PolKit version for patch params
-      ansible.builtin.shell: pkaction --version
+      ansible.builtin.shell: pkaction --version | rev | cut -d' ' -f1 | rev
       changed_when: false
       register: pk_version
       when: xrdp.colord_bypass
-
+      
     - name: XRDP | 9.2 | Ensure that colord patch is applied to the system - 'PolKit v0.106-'
       ansible.builtin.template:
         src: 45-allow-colord.j2

--- a/tasks/xrdp.yml
+++ b/tasks/xrdp.yml
@@ -56,12 +56,38 @@
     - { key: 'LogLevel', line: 'LogLevel=INFO' }
     - { key: 'SyslogLevel', line: 'LogLevel=INFO' }
 
-- name: XRDP | 9.0 | Ensure XRDP configuration is applied by restarting the service
+- name: XRDP | 9.0 | Patch Polkit
+  block:
+    - name: XRDP | 9.1 | Gather PolKit version for patch params
+      ansible.builtin.shell: pkaction --version
+      changed_when: false
+      register: pk_version
+      when: xrdp.colord_bypass
+
+    - name: XRDP | 9.2 | Ensure that colord patch is applied to the system - 'PolKit v0.106-'
+      ansible.builtin.template:
+        src: 45-allow-colord.j2
+        dest: /etc/polkit-1/localauthority/50-local.d/45-allow-colord.pkla
+        group: root
+        owner: root
+        mode: 0751
+      when: xrdp.colord_bypass and pk_version.stdout is version('0.106', '<')
+
+    - name: XRDP | 9.2 | Ensure that colord patch is applied to the system - 'PolKit v0.106+'
+      ansible.builtin.template:
+        src: 45-allow-colord.j2
+        dest: /etc/polkit-1/localauthority/50-local.d/45-allow-colord.conf
+        group: root
+        owner: root
+        mode: 0751
+      when: xrdp.colord_bypass and pk_version.stdout is version('0.106', '>=')
+
+- name: XRDP | 11.0 | Ensure XRDP configuration is applied by restarting the service
   ansible.builtin.systemd:
     name: xrdp
     state: restarted
 
-- name: XRDP | 10.0 | Ensure XRDP user is added to the ssl-certs group
+- name: XRDP | 12.0 | Ensure XRDP user is added to the ssl-certs group
   ansible.builtin.user:
     name: xrdp
     groups: ssl-cert

--- a/templates/45-allow-colord.j2
+++ b/templates/45-allow-colord.j2
@@ -1,0 +1,6 @@
+[Allow Colord all Users]
+Identity=unix-group:{{ xrdp.colord_group }}
+Action=org.freedesktop.color-manager.create-device;org.freedesktop.color-manager.create-profile;org.freedesktop.color-manager.delete-device;org.freedesktop.color-manager.delete-profile;org.freedesktop.color-manager.modify-device;org.freedesktop.color-manager.modify-profile
+ResultAny=no
+ResultInactive=no
+ResultActive=yes

--- a/test.yml
+++ b/test.yml
@@ -1,0 +1,16 @@
+---
+- hosts: xrdp
+  become: true
+
+  # Generic pre-tasks
+  pre_tasks:
+    - name: PRE TASKS | 1.0 | Load variables from provided configuration file
+      ansible.builtin.include_vars: config.yml
+    - name: PRE TASKS | 2.0 | Ensure Apt Cache is up-to-date
+      ansible.builtin.apt:
+        update_cache: true
+        cache_valid_time: 3600
+      when: ansible_facts.os_family == "Debian"
+
+  roles:
+    - '.'


### PR DESCRIPTION
This infamous issue with XRDP seems to cause problems with some system services that are supposed to start automatically when the server is restarted. Instead they seem to freeze until a user logs into the account via RDP and either authenticates or dismisses the error.

The solution was by adding a bypass for special groups who run these types of services that may have problems.